### PR TITLE
Added spaces inside interpolated expressions

### DIFF
--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -3,7 +3,7 @@
     <div class="fs-calendar-header">
       <span class="fs-calendar-prev" data-ng-click="prevYearRange()"></span>
       <span class="fs-calendar-title" data-ng-click="switchSelectionMode()">
-        {{years[0]}}-{{years[years.length-1]}}
+        {{ years[0] }}-{{ years[years.length-1] }}
       </span>
       <span class="fs-calendar-next" data-ng-click="nextYearRange()"></span>
     </div>
@@ -13,7 +13,7 @@
             data-ng-click="selectYear(year)"
             data-ng-class="{'active': year == selectedYear}"
             class="year">
-          {{year}}
+          {{ year }}
         </td>
       </tr>
     </table>
@@ -22,7 +22,7 @@
     <div class="fs-calendar-header">
       <span class="fs-calendar-prev" data-ng-click="prevYear()"></span>
       <span class="fs-calendar-title" data-ng-click="switchSelectionMode()">
-        {{selectedYear}}
+        {{ selectedYear }}
       </span>
       <span class="fs-calendar-next" data-ng-click="nextYear()"></span>
     </div>
@@ -32,7 +32,7 @@
             data-ng-click="selectMonth(month)"
             data-ng-class="{'active': month == selectedMonth && isSameYear()}"
             class="month">
-          {{month}}
+          {{ month }}
         </td>
       </tr>
     </table>
@@ -41,7 +41,7 @@
     <div class="fs-calendar-header">
       <span class="fs-calendar-prev" data-ng-click="prevMonth()"></span>
       <span class="fs-calendar-title" data-ng-click="switchSelectionMode()">
-        {{selectedMonth + ', ' + selectedYear}}
+        {{ selectedMonth + ', ' + selectedYear }}
       </span>
       <span class="fs-calendar-next" data-ng-click="nextMonth()"></span>
     </div>
@@ -49,7 +49,7 @@
       <thead>
       <tr>
         <th data-ng-repeat="weekDay in weekDays">
-          {{weekDay}}
+          {{ weekDay }}
         </th>
       </tr>
       </thead>
@@ -60,7 +60,7 @@
                        'day-current': isCurrentDate(day),
                        'active bg-info': isSelectedDate(day)}"
             data-ng-click="selectDay(day)">
-          {{day.getDate()}}
+          {{ day.getDate() }}
         </td>
       </tr>
       </tbody>

--- a/templates/date.html
+++ b/templates/date.html
@@ -12,7 +12,7 @@
      class="form-control"
      ng-model="selectedDate.date"
      fs-date-format
-     placeholder="{{placeholder}}"
+     placeholder="{{ placeholder }}"
      fs-null-form />
   <span class="glyphicon glyphicon-calendar" ng-click='active = !disabled'></span>
 

--- a/templates/field.html
+++ b/templates/field.html
@@ -1,15 +1,15 @@
 <div class='form-group'
      ng-class='{"has-error": object.$errors[field].length > 0}'>
-  <label for='{{objectName}}[{{field}}]' class='col-sm-2 control-label'>Name</label>
+  <label for='{{ objectName }}[{{ field }}]' class='col-sm-2 control-label'>Name</label>
   <div class='col-sm-10'>
     <div w-combo
          class='w-field-input'
          items='items'
          invalid='object.$errors[field]'
-         name='{{objectName}}[{{field}}]' 
+         name='{{ objectName }}[{{ field }}]'
          ng-model='object[field]'></div>
     <div>
-      <p ng-repeat='error in object.$errors[field]' class='text-danger'>{{error}}</p>
+      <p ng-repeat='error in object.$errors[field]' class='text-danger'>{{ error }}</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
I had hard times searching for the reason fsCalendar couldn't render. I found it was because '{{years[0]}}' was interpreted as '[[years[0]]]' as I have '[[' and ']]' as interpolation start and stop symbols respectively (because '{{' and '}}' interfere with jinja2 templating). Adding spaces solved the problem.
